### PR TITLE
Remove redundant Java installation steps

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -19,12 +19,6 @@ jobs:
 
       - name: "Package ontology"
         run: python /app/package.py opencs package dev
-        
-      - name: "Install Java"
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
           
       - name: "Infer additional assertions"
         run: |

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -20,12 +20,6 @@ jobs:
       - name: "Package ontology"
         run: python /app/package.py opencs package "$GITHUB_REF_NAME"
 
-      - name: "Install Java"
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
       - name: "Infer additional assertions"
         run: |
           bash /app/inference/infer_assertions.sh


### PR DESCRIPTION
Once [https://github.com/OpenCS-ontology/ci-worker/pull/13](https://github.com/OpenCS-ontology/ci-worker/pull/13) is merged, these steps are no longer necessary, so we can remove them and speed up the pipeline excecution.
This will resolve [https://github.com/OpenCS-ontology/OpenCS/issues/15](https://github.com/OpenCS-ontology/OpenCS/issues/15)