### PR TITLE
feat: added convertion to jsonld for webbrowser

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -72,7 +72,7 @@ jobs:
           destination-github-username: 'opencs-ontology'
           destination-repository-name: 'opencs-ontology.github.io'
           user-name: ci-worker
-          target-directory: browser
+          target-directory: assets/data
           target-branch: main
 
       - name: "Push files for current tag version"

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -48,6 +48,9 @@ jobs:
         run: |
           TAG_PATH=/releases/${GITHUB_REF_NAME#v}
           echo "TAG_PATH=$TAG_PATH" >> $GITHUB_ENV
+      
+      - name: "Convert concepts to JSONLD files for ontology web browser"
+        run: python /app/convert_to_jsonld.py stable/opencs.ttl browser
 
       - name: "Generate pages for Github Pages repository"
         run: python /app/generate_pages.py ${GITHUB_REF_NAME#v} $GITHUB_REPOSITORY output_files
@@ -59,6 +62,18 @@ jobs:
           cp output_files/page.md tag/index.md
           cp output_files/page.md stable/index.md
           cp output_files/versions.md versions/index.md
+      
+      - name: "Push JSONLD browser directory to the website repo"
+        uses: "cpina/github-action-push-to-another-repository@main"
+        env: 
+          SSH_DEPLOY_KEY: ${{ secrets.SSH_DEPLOY_KEY }}
+        with:
+          source-directory: 'browser'
+          destination-github-username: 'opencs-ontology'
+          destination-repository-name: 'opencs-ontology.github.io'
+          user-name: ci-worker
+          target-directory: browser
+          target-branch: main
 
       - name: "Push files for current tag version"
         uses: "cpina/github-action-push-to-another-repository@main"


### PR DESCRIPTION
This is related to [PR#15](https://github.com/OpenCS-ontology/ci-worker/pull/15 ) for ci-worker. 

The added stages add running python script for convertion of opencs.ttl file to individual JSONLD files and saving the output directory in the target /browser directory of the [https://github.com/OpenCS-ontology/OpenCS-ontology.github.io/tree/main](https://github.com/OpenCS-ontology/OpenCS-ontology.github.io/tree/main)