### PR TITLE
Switch to Jena-based SHACL validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,4 +21,11 @@ jobs:
           path: opencs
 
       - name: "Validate ontology with SHACL"
-        run: python /app/validate.py opencs
+        run: bash /app/validate_jena.sh
+
+      - name: "Upload validation report"
+        if: '!cancelled()'
+        uses: actions/upload-artifact@v3
+        with:
+          name: validation_report
+          path: package/validation_report.ttl

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: opencs
 


### PR DESCRIPTION
Switch to Jena-based SHACL validation and add validation-report run artifact.
This should resolve https://github.com/OpenCS-ontology/OpenCS/issues/23.
Ideally this should be merged after https://github.com/OpenCS-ontology/ci-worker/pull/16, but it should work even now.