### PR TITLE
Add SHACL disjoint rule for skos:broader & skos:related

### DIFF
--- a/ontology/shacl_constraints.ttl
+++ b/ontology/shacl_constraints.ttl
@@ -58,3 +58,13 @@ ocsh:NoCyclesRule
 		sh:path  ([sh:oneOrMorePath skos:broader] skos:prefLabel) ;
 		sh:disjoint skos:prefLabel ;
 	] .
+
+ocsh:RelatedBroaderDisjoint 
+	a sh:NodeShape ;
+	sh:targetClass skos:Concept ;
+	sh:message "Hierarchical links (skos:broader, transitively) and associative links (skos:related) should be disjoint" ;
+	sh:property [
+		sh:severity sh:Warning ;
+		sh:path [ sh:oneOrMorePath skos:broader ; ] ;
+		sh:disjoint skos:related ;
+	] .


### PR DESCRIPTION
This PR will introduce a new SHACL check to verify the disjointness of `skos:broader` (including transitively) and `skos:broader`. 
Related to https://github.com/OpenCS-ontology/OpenCS/issues/27 and should be the first step to addressing the issue. Currently the rule is marked as a `sh:severity` `sh:Warning`, due to the low impact. The rule was tested on my fork of the repo https://github.com/niegrzybkowski/OpenCS/commits/main. With Apache Jena validation it takes ~20s for the validation step. The rule detected 27 000 violations and reported it in the logs and the validation report.

This should be merged after https://github.com/OpenCS-ontology/OpenCS/pull/33, due to the increased validation performance.
